### PR TITLE
build(action): update gitHub Actions to release versions

### DIFF
--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-latest.yml
@@ -102,7 +102,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
@@ -131,7 +131,7 @@ jobs:
 
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -146,7 +146,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container # `docker-container` is default
           # buildkitd-flags: "--debug" # open buildkitd flags
@@ -170,7 +170,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
@@ -210,7 +210,7 @@ jobs:
 
       -
         name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -241,7 +241,7 @@ jobs:
 
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -251,7 +251,7 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -267,7 +267,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       -
         name: Login to DockerHub

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-hubdocker-tag.yml
@@ -101,7 +101,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
@@ -130,7 +130,7 @@ jobs:
 
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -145,7 +145,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container # `docker-container` is default
           # buildkitd-flags: "--debug" # open buildkitd flags
@@ -169,7 +169,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
@@ -209,7 +209,7 @@ jobs:
 
       -
         name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -240,7 +240,7 @@ jobs:
 
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -250,7 +250,7 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -266,7 +266,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       -
         name: Login to DockerHub

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-latest.yml
@@ -107,7 +107,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
@@ -137,7 +137,7 @@ jobs:
 
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -152,7 +152,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container # `docker-container` is default
           # buildkitd-flags: "--debug" # open buildkitd flags
@@ -185,7 +185,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
@@ -225,7 +225,7 @@ jobs:
 
       -
         name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -256,7 +256,7 @@ jobs:
 
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -266,7 +266,7 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -282,7 +282,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       -
         name: Login to DockerHub

--- a/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
+++ b/.github/workflows-template/docker-buildx-bake/docker-buildx-bake-multi-tag.yml
@@ -106,7 +106,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
@@ -135,7 +135,7 @@ jobs:
 
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -150,7 +150,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container # `docker-container` is default
           # buildkitd-flags: "--debug" # open buildkitd flags
@@ -183,7 +183,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
@@ -223,7 +223,7 @@ jobs:
 
       -
         name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -254,7 +254,7 @@ jobs:
 
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -264,7 +264,7 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -280,7 +280,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       -
         name: Login to DockerHub

--- a/.github/workflows-template/docker-image/docker-image-latest.yml
+++ b/.github/workflows-template/docker-image/docker-image-latest.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
           tags: |
@@ -67,7 +67,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container # `docker-container` is default
       -
@@ -96,7 +96,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
           tags: |
@@ -113,7 +113,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container # `docker-container` is default
       -

--- a/.github/workflows-template/docker-image/docker-image-tag.yml
+++ b/.github/workflows-template/docker-image/docker-image-tag.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
           tags: |
@@ -56,7 +56,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Build dry
         uses: docker/build-push-action@v5 # https://github.com/marketplace/actions/build-and-push-docker-images
@@ -83,7 +83,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
           tags: |
@@ -100,7 +100,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Build and push
         id: docker_push

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -54,7 +54,7 @@ jobs:
           echo "download_artifact_name: ${{ inputs.download_artifact_name }}"
 
       - name: Download Artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         if: ${{ inputs.download_artifact_name != null }}
         with:
           path: ${{ github.workspace }}/disd d dt

--- a/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-latest.yml
@@ -102,7 +102,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
@@ -131,7 +131,7 @@ jobs:
 
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-latest-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -146,7 +146,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container # `docker-container` is default
           # buildkitd-flags: "--debug" # open buildkitd flags
@@ -170,7 +170,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
@@ -210,7 +210,7 @@ jobs:
 
       -
         name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: digests-latest-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -241,7 +241,7 @@ jobs:
 
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -251,7 +251,7 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -267,7 +267,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       -
         name: Login to DockerHub

--- a/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
+++ b/.github/workflows/docker-buildx-bake-hubdocker-tag.yml
@@ -101,7 +101,7 @@ jobs:
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ vars.ENV_DOCKERHUB_OWNER }}/${{ vars.ENV_DOCKERHUB_REPO_NAME }}
@@ -130,7 +130,7 @@ jobs:
 
       -
         name: Upload meta bake definition
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: bake-tag-meta-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -145,7 +145,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container # `docker-container` is default
           # buildkitd-flags: "--debug" # open buildkitd flags
@@ -169,7 +169,7 @@ jobs:
       -
         name: Build
         id: bake
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         timeout-minutes: ${{ inputs.docker-build-timeout-minutes }} # default 360
         with:
           files: |
@@ -209,7 +209,7 @@ jobs:
 
       -
         name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.push_remote_flag }}
         with:
           name: digests-tag-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.docker_bake_targets }}-${{ env.PLATFORM_PAIR }}
@@ -240,7 +240,7 @@ jobs:
 
       -
         name: Download meta bake definition
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: bake-meta
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -250,7 +250,7 @@ jobs:
 
       -
         name: Download digests
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           # name: digests
           ## https://github.com/actions/download-artifact/tree/v4?tab=readme-ov-file#breaking-changes
@@ -266,7 +266,7 @@ jobs:
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       -
         name: Login to DockerHub

--- a/.github/workflows/go-release-platform.yml
+++ b/.github/workflows/go-release-platform.yml
@@ -121,7 +121,7 @@ jobs:
           echo " archive sha256sum at: ${{ env.ASSET }}.sha256"
 
       - name: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.upload_artifact_name != null }}
         with:
           name: ${{ inputs.upload_artifact_name }}-${{ inputs.version_name }}-${{ matrix.go_os }}-${{ matrix.go_arch }}

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -67,7 +67,7 @@ jobs:
         # https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#compatibility
         # * `v8.0.0` works with `golangci-lint` version >= `v2.1.0`
         # * `v7.0.0` supports golangci-lint v2 only.
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/goreleaser-golang.yml
+++ b/.github/workflows/goreleaser-golang.yml
@@ -87,7 +87,7 @@ jobs:
 
       -
         name: version GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
@@ -97,7 +97,7 @@ jobs:
 
       -
         name: healthcheck GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
@@ -107,7 +107,7 @@ jobs:
 
       -
         name: check GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
@@ -117,7 +117,7 @@ jobs:
 
       -
         name: DryRun build GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         if: ${{ inputs.dry_run }}
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
@@ -128,7 +128,7 @@ jobs:
 
       -
         name: DryRun release GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         if: ${{ inputs.dry_run }}
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
@@ -143,7 +143,7 @@ jobs:
 
       -
         name: build GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         if: ${{ ! inputs.dry_run }}
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
@@ -158,7 +158,7 @@ jobs:
 
       -
         name: release GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         if: ${{ ! inputs.dry_run }}
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
@@ -172,7 +172,7 @@ jobs:
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ inputs.upload_artifact_name != null || ! inputs.dry_run }}
         with:
           name: ${{ inputs.upload_artifact_name }}-${{ inputs.version_name }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/doc-dev/dev.md
+++ b/doc-dev/dev.md
@@ -17,10 +17,9 @@
 
 - change goreleaser
     - from [goreleaser docker tags](https://hub.docker.com/r/goreleaser/goreleaser/tags) to new version
-    - `goreleaser/goreleaser:v2.9.0`
+    - `golangci/golangci-lint-action@v8`
     - from [goreleaser version release](https://github.com/goreleaser/goreleaser/releases) to new version
 
-## depends
 
 in go mod project
 


### PR DESCRIPTION
### Description of Changes

- Upgrade actions/download-artifact to v8 to ensure the use of the latest features and fixes.
- Upgrade docker/metadata-action to v6 to enhance the stability of metadata processing.
- Upgrade actions/upload-artifact to v7 to improve the performance of artifact upload.
- Upgrade docker/setup-buildx-action to v4 to ensure compatibility with the latest Docker Buildx.
- Upgrade docker/bake-action to v7 to optimize the build process.
- These changes are intended to improve the reliability and efficiency of the CI/CD pipeline.

### Related Issues

List related issues here

- #75